### PR TITLE
allpass: additional tests of changing delay settings

### DIFF
--- a/test/allpass/allpass_test.cpp
+++ b/test/allpass/allpass_test.cpp
@@ -114,3 +114,79 @@ SCENARIO ("Produce the correct impulse response") {
 		}
 	}
 }
+
+SCENARIO ("Using non-default settings") {
+    
+    WHEN ("Overriding the default capacity for allpass filter") {
+        c74::min::lib::allpass	f(4800);
+        
+        THEN("The size has been set correctly.")
+        
+        REQUIRE( f.delay() == 4800 );
+    
+        WHEN("Changing the size to less than default capacity") {
+            
+            f.delay(1000);
+            
+            THEN("The size has been set correctly.")
+            
+            REQUIRE( f.delay() == 1000 );
+            
+
+        
+            WHEN ("processing a 1100-sample impulse") {
+                // create an impulse buffer to process
+                const int				buffersize = 1100;
+                c74::min::sample_vector	impulse(buffersize);
+                
+                std::fill_n(impulse.begin(), buffersize, 0.0);
+                impulse[0] = 1.0;
+                
+                // output from our object's processing
+                c74::min::sample_vector	output;
+                
+                // run the calculations
+                for (auto x : impulse) {
+                    auto y = f(x);
+                    output.push_back(y);
+                }
+                
+            }
+            
+            // What can we test here?
+            
+            WHEN("Changing the size again to a higher value, but still less than default capacity")
+            
+            f.delay(2000);
+            
+            THEN("The size has been set correctly.")
+            
+            REQUIRE( f.delay() == 2000 );
+            
+            WHEN ("processing another 1100-sample impulse") {
+                // create an impulse buffer to process
+                const int				buffersize = 1100;
+                c74::min::sample_vector	impulse(buffersize);
+                
+                std::fill_n(impulse.begin(), buffersize, 0.0);
+                impulse[0] = 1.0;
+                
+                // output from our object's processing
+                c74::min::sample_vector	output;
+                
+                // run the calculations
+                for (auto x : impulse) {
+                    auto y = f(x);
+                    output.push_back(y);
+                }
+                
+            }
+            
+            // What can we test here?
+            
+        }
+        
+    }
+    
+}
+


### PR DESCRIPTION
see Cycling74/min-lib/issue #12

Some additional tests of changing the delay settings on allpass that I developed. The problem proved to be elsewhere, but these tests are worth preserving and possibly even expanding. If you have specific suggestion about expansion, please open a new issue with notes.