### PR TITLE
Fix for issue #20 w test

### DIFF
--- a/include/c74_lib_circular_storage.h
+++ b/include/c74_lib_circular_storage.h
@@ -172,11 +172,20 @@ namespace lib {
 
 		///	Zero the contents without resizing.
 	
-		void clear() {
+		void zero() {
             assert(check_thread());
-			T empty_value;
-            std::fill(m_items.begin(),m_items.end(),empty_value);
+			T zero_value = T(); // call the constructor to ensure zero initialization
+            std::fill(m_items.begin(),m_items.end(),zero_value);
 		}
+        
+        
+        /// Clear the contents, leaving internal vector with a size of zero.
+        
+        void clear() {
+            assert(check_thread());
+            m_items.clear();
+            m_size = 0;
+        }
 
 
 		///	Return the item count of the container.
@@ -195,10 +204,10 @@ namespace lib {
 		void resize(std::size_t	new_size) {
 			assert(new_size <= m_items.size());
 			m_size = new_size;
-            // if m_index is out of bounds after resize, we clear the memory to prevent invalid output from history
+            // if m_index is out of bounds after resize, we zero the memory to prevent invalid output from history
             if (m_index >= m_size) {
                 m_index = 0;
-                clear();
+                zero();
             }
 		}
 

--- a/include/c74_lib_circular_storage.h
+++ b/include/c74_lib_circular_storage.h
@@ -170,11 +170,12 @@ namespace lib {
 		}
 
 
-		///	Zero the contents.
+		///	Zero the contents without resizing.
 	
 		void clear() {
             assert(check_thread());
-			m_items.clear();
+			T empty_value;
+            std::fill(m_items.begin(),m_items.end(),empty_value);
 		}
 
 
@@ -194,6 +195,11 @@ namespace lib {
 		void resize(std::size_t	new_size) {
 			assert(new_size <= m_items.size());
 			m_size = new_size;
+            // if m_index is out of bounds after resize, we clear the memory to prevent invalid output from history
+            if (m_index >= m_size) {
+                m_index = 0;
+                clear();
+            }
 		}
 
 

--- a/test/allpass/allpass_test.cpp
+++ b/test/allpass/allpass_test.cpp
@@ -1002,7 +1002,9 @@ TEST_CASE( "produces valid output after sudden drop in delay time" ) {
         output.push_back(y);
     }
     
-    REQUIRE( output[0] == output[128] );
-    REQUIRE( output[1] == output[129] );
+    INFO( "Compare the last 64 samples to the first 64 samples. They should be the same." );
+    for (auto x : impulse) {
+        REQUIRE( output[x] == output[x+128] );
+    }
     
 }

--- a/test/allpass/allpass_test.cpp
+++ b/test/allpass/allpass_test.cpp
@@ -937,3 +937,72 @@ TEST_CASE( "survives a sudden drop in delay time without crashing" ) {
     REQUIRE( output != impulse );
     
 }
+
+// NW: developed in response to issue here: https://github.com/Cycling74/min-lib/issues/19
+TEST_CASE( "produces valid output after sudden drop in delay time" ) {
+    
+    using namespace c74::min;
+    using namespace c74::min::lib;
+    
+    size_t test_size = 44100;
+    
+    INFO( "Start with a new instance of the allpass object." );
+    // create an instance of our object
+    allpass my_object { test_size };
+    
+    // create a vector to save output from our object's processing
+    sample_vector	output;
+    
+    INFO( "Setup an impulse that is just shorter than the allpass circular_storage." );
+    // create an impulse buffer to process
+    const int		buffersize = 64;
+    sample_vector	impulse(buffersize, 0.0);
+    impulse[0] = 1.0;
+    
+    // change the delay_time to something larger than the default
+    INFO( "Change the delay_time attribute to 4 samples (approx 0.1 ms)." );
+    my_object.delay(4);
+    my_object.gain(0.5);
+    
+    REQUIRE( my_object.delay() == 4 );
+    // note that this is our object's attribute only
+    // value does not actually get changed for the allpass circular_storage until the next call to its sample_operator
+    
+    // run the calculations
+    INFO( "Push the impulse sample_vector through the allpass object one time." );
+    for (auto x : impulse) {
+        auto y = my_object(x);
+        output.push_back(y);
+    }
+    
+    
+    // change the delay_time to something larger than the default
+    INFO( "Change the delay_time attribute UP to 44 samples (approx 1 ms)." );
+    my_object.delay(44);
+    REQUIRE( my_object.delay() == 44 );
+    
+    // run the calculations
+    INFO( "Push the impulse sample_vector through the allpass object one time." );
+    for (auto x : impulse) {
+        auto y = my_object(x);
+        output.push_back(y);
+    }
+    
+    
+    // change the delay_time to something smaller
+    INFO( "Change the delay_time attribute BACK DOWN to 4 samples (approx 0.1 ms)." );
+    my_object.delay(4);
+    REQUIRE( my_object.delay() == 4 );
+    
+    // run the calculations again, which should wrap around the internal circular_storage
+    INFO( "Push the impulse sample_vector through the allpass object another time." );
+    for (auto x : impulse) {
+        // CRASH HAPPENS HERE
+        auto y = my_object(x);
+        output.push_back(y);
+    }
+    
+    REQUIRE( output[0] == output[128] );
+    REQUIRE( output[1] == output[129] );
+    
+}

--- a/test/circular_storage/circular_storage_test.cpp
+++ b/test/circular_storage/circular_storage_test.cpp
@@ -232,14 +232,41 @@ TEST_CASE ("Using Circular Storage as the basis for an Audio Delay") {
 	circ.write(samples);
 }
 
-TEST_CASE ("Test that clear() does not resize Circular Storage") {
+TEST_CASE ("Test zero() and clear() functions of Circular Storage") {
     INFO ("Using an 8-sample circular buffer")
     c74::min::lib::circular_storage<c74::min::sample>	circ(8);	// 8 samples
+    c74::min::sample_vector								samples = {1,2,3,4,5,6,7,8};
     
+    INFO("The default size will be the capacity of the circular buffer (8 samples)");
     REQUIRE( circ.size() == 8 );
     
+    INFO("After we write in 8 values, the internal storage is updated with the new items in the correct locations");
+    circ.write(samples);
+    REQUIRE( circ.item(0) == 1 );
+    REQUIRE( circ.item(1) == 2 );
+    REQUIRE( circ.item(2) == 3 );
+    REQUIRE( circ.item(3) == 4 );
+    REQUIRE( circ.item(4) == 5 );
+    REQUIRE( circ.item(5) == 6 );
+    REQUIRE( circ.item(6) == 7 );
+    REQUIRE( circ.item(7) == 8 );
+    
+    INFO("After we call zero(), the size of the internal storage in unchanged...");
+    circ.zero();
+    REQUIRE( circ.size() == 8 );
+    
+    INFO("...but all values have been set to zero");
+    REQUIRE( circ.item(0) == 0 );
+    REQUIRE( circ.item(1) == 0 );
+    REQUIRE( circ.item(2) == 0 );
+    REQUIRE( circ.item(3) == 0 );
+    REQUIRE( circ.item(4) == 0 );
+    REQUIRE( circ.item(5) == 0 );
+    REQUIRE( circ.item(6) == 0 );
+    REQUIRE( circ.item(7) == 0 );
+    
+    INFO("After we call clear(), the internal storage has a size of 0");
     circ.clear();
-    
-    REQUIRE( circ.size() == 8 );
+    REQUIRE( circ.size() == 0 );
     
 }

--- a/test/circular_storage/circular_storage_test.cpp
+++ b/test/circular_storage/circular_storage_test.cpp
@@ -231,3 +231,15 @@ TEST_CASE ("Using Circular Storage as the basis for an Audio Delay") {
 	samples = {29,30,31,32};
 	circ.write(samples);
 }
+
+TEST_CASE ("Test that clear() does not resize Circular Storage") {
+    INFO ("Using an 8-sample circular buffer")
+    c74::min::lib::circular_storage<c74::min::sample>	circ(8);	// 8 samples
+    
+    REQUIRE( circ.size() == 8 );
+    
+    circ.clear();
+    
+    REQUIRE( circ.size() == 8 );
+    
+}


### PR DESCRIPTION
See Cycling74/min-lib/issue #20
Fix applies if @tap agrees that this is the intended behavior for `circular_storage::clear()`

It would also help to address Cycling74/min-lib/issue #19 
but I would need to do a bit more clean up to finish that one.